### PR TITLE
Fix missing watchers in scoring

### DIFF
--- a/analyzer/github_repo_analyzer.go
+++ b/analyzer/github_repo_analyzer.go
@@ -206,7 +206,8 @@ func calcScore(repoInfo *GitHubRepoInfo, weights *ParameterWeights) {
 		utils.StdErrorPrintln("Date Format Error: %v", err)
 	}
 
-	score := float64(repoInfo.Stars) * weights.Stars
+	score := float64(repoInfo.Watchers) * weights.Watchers
+	score += float64(repoInfo.Stars) * weights.Stars
 	score += float64(repoInfo.Forks) * weights.Forks
 	score += float64(repoInfo.OpenIssues) * weights.OpenIssues
 	score += float64(days) * weights.LastCommitDate

--- a/analyzer/github_repo_analyzer_test.go
+++ b/analyzer/github_repo_analyzer_test.go
@@ -62,3 +62,44 @@ func TestFetchGithubInfo(t *testing.T) {
 	assert.False(t, repoInfo.Archived, "Archived should be false")
 	assert.False(t, repoInfo.Skip, "Skip should be false")
 }
+
+func TestScoreIncludesWatchers(t *testing.T) {
+	t.Parallel()
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/example-owner/example-repo",
+		httpmock.NewStringResponder(200, `{
+                        "name": "example-repo",
+                        "subscribers_count": 10,
+                        "stargazers_count": 50,
+                        "forks_count": 5,
+                        "open_issues_count": 3,
+                        "archived": false,
+                        "default_branch": "main"
+                }`))
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/example-owner/example-repo/commits/main",
+		httpmock.NewStringResponder(200, `{
+                        "commit": {
+                                "committer": {
+                                        "date": "2023-10-01T12:00:00Z"
+                                }
+                        }
+                }`))
+
+	analyzer := analyzer.NewGitHubRepoAnalyzer("dummy-token", analyzer.ParameterWeights{
+		Watchers:       2.0,
+		Stars:          0.0,
+		Forks:          0.0,
+		OpenIssues:     0.0,
+		LastCommitDate: 0.0,
+		Archived:       0.0,
+	})
+
+	repoInfos := analyzer.FetchGithubInfo([]string{"https://api.github.com/repos/example-owner/example-repo"})
+
+	assert.Len(t, repoInfos, 1)
+	assert.Equal(t, 20, repoInfos[0].Score)
+}


### PR DESCRIPTION
## Summary
- factor watcher count into score calculation
- test scoring with watcher weights

## Testing
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68427864813083208682fbd981c3530e